### PR TITLE
Added proxy awareness for building

### DIFF
--- a/PowerLine/PLBuilderMain.cs
+++ b/PowerLine/PLBuilderMain.cs
@@ -260,6 +260,8 @@ namespace PLBuilder
                 string scriptName = script.Substring(script.LastIndexOf('/') + 1);
                 using (WebClient client = new WebClient())
                 {
+                    client.Proxy = WebRequest.GetSystemWebProxy();
+                    client.Proxy.Credentials = CredentialCache.DefaultCredentials;
                     using (MemoryStream mStream = new MemoryStream(client.DownloadData(new Uri(script))))
                     {
 


### PR DESCRIPTION
The System.Net.WebClient can use the logged on user's credentials on the system to authenticate to the proxy. Empire uses this in its PowerShell launcher. I just threw it in so if building on a remote system we can authetnicate to pull down remote scripts over the proxy.

You could also set credentials to authenticate to the proxy but you obviously need to include command line switches for the build script, so I didn't include.

Cool project, interested to try during an assessment.